### PR TITLE
Added logging for task attempt and task status

### DIFF
--- a/prompts/coverage_debugger_system.prompt
+++ b/prompts/coverage_debugger_system.prompt
@@ -27,7 +27,7 @@ You are expected to provide the following output:
 You will be provided the following tools to explore the verification and project directory:
 1. Bash tool: This tool will allow you to run bash commands such as grep that can help search the repo for relevant information. 
 2. CScope tool: The target repository has already been indexed with cscope. This tool allows you to run cscope commands to retrieve type definitions, function cross-references, and full paths to specific files.
-3. Get Condition Satisfiability Tool: This tool will allow you inspect if conditions on a specific program line can be satisfied in the harness or not. This can help you debug uncovered code blocks guarded by multiple conditions as it tells you which of the conditions are not being satisfied.
+3. Get Condition Satisfiability Tool: This tool will allow you inspect the satisfiability of conditions in a specific IF statement in the progrma. This can help you debug uncovered code blocks guarded by multiple conditions as it tells you which of the conditions are not being satisfied.
 
 Here are sample cscope commands to run:
 # --- Symbol and function lookups ---
@@ -50,8 +50,8 @@ There are three common types of coverage gaps. First classifying a gap into one 
 
 Type 1: If-related uncovered blocks.
 These are uncovered blocks guarded by an if condition and which are uncovered because the if condition is always false.
-To resolve, first reason about the if condition and determine the reasons why the block conditions cannot be satisfied.
-If the if statement contains multiple conditions, you can use the provided tools to determine which condition is unsatisfiable.
+To resolve, if the IF statement have multiple conditions, use the condition satisfiability tool to determine which conditions in the IF statement is unsatisfiable.
+Then, analyze the code and determine why the corresponding conditions cannot be satisfied.
 Note that, it is possible that the if condition is never satisfied and the uncovered block is a dead code. If this occurs, provide your analysis but do not make any further modifications.
 
 Type 2: Loop-related uncovered blocks.

--- a/src/agent.py
+++ b/src/agent.py
@@ -279,7 +279,7 @@ class AIAgent(ABC):
             {
                 "type": "function",
                 "name": "get_condition_satisfiability",
-                "description": "Retrieve the satisfiability of the conditions present at a specific line in a function.",
+                "description": "Retrieve the status and satisfiability of conditions present in a specific IF statement.",
                 "strict": True,
                 "parameters": {
                     "type": "object",

--- a/src/run.py
+++ b/src/run.py
@@ -66,6 +66,10 @@ def get_parser():
         "--log_file",
         help="Path where log file should be saved."
     )
+    parser.add_argument(
+        "--metrics_file",
+        help="Path where metrics file should be saved."
+    )
     return parser.parse_args()
 
 
@@ -110,6 +114,7 @@ def process_mode(args):
             harness_dir=args.harness_path,
             target_func=args.target_function_name,
             target_file_path=args.target_file_path,
+            metrics_file=args.metrics_file,
             project_container=project_container
         ))
     if args.mode in ["debugger", "all"]:


### PR DESCRIPTION
This PR makes 3 main changes:
- Introduces a --metric_file argument, which provides a file to log llm-based metrics. If a file is not provided, the metric is not logged.
- Introduces 2 functions in agent.py for logging each fix attempt and the final status of the task (after all attempts).
- Updates the coverage debugger so it logs each attempt and the task accordingly.